### PR TITLE
remove ability for anybody to see /users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_filter :authenticate_user!
-  before_filter :correct_user?, :except => [:index]
-
+  before_filter :correct_user?, except: [:index, :show]
+  load_and_authorize_resource except: [:show, :edit]
   def index
     @users = User.all
   end


### PR DESCRIPTION
This is what allows us to stop people from viewing `/users`. 

However, this solution appears to be interesting and useful for restricting everybody except admin from viewing `/users`. It's done by adding a method `authenticate_admin!` to the `application_controller.rb`:

``` ruby
def authenticate_admin!
  unless current_user && current_user.admin?
    redirect_to root_url, :alert => 'You cannot access that page.'
  end
end
```

With the code above, you'd have to define a `admin?` method on User (I'm not sure how your role system works, but it should be straightforward). You'd then add `before_filter :authenticate_admin!, only: [:index]` to your `UsersController`.

Sorry, not much experience with `cancan`, but hopefully this is helpful.
