### PR TITLE
Add Flat-UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem "factory_girl_rails", ">= 4.1.0"
 end
 
+gem 'flat-ui-rails'
 gem 'jquery-rails'
 gem "thin", ">= 1.5.0"
 # Per http://packages.qa.debian.org/m/mongodb.html

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     figaro (0.6.3)
       bundler (~> 1.0)
       rails (>= 3, < 5)
+    flat-ui-rails (0.0.2)
     gherkin (2.11.6)
       json (>= 1.7.6)
     hashie (1.2.0)
@@ -235,6 +236,7 @@ DEPENDENCIES
   email_spec (>= 1.4.0)
   factory_girl_rails (>= 4.1.0)
   figaro (~> 0.6)
+  flat-ui-rails
   jquery-rails
   launchy (>= 2.1.2)
   less-rails (>= 2.2.6)

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -8,6 +8,8 @@
  * You're free to add application-wide styles to this file and they'll appear at the top of the
  * compiled file, but it's generally better to create a new file per style scope.
  *
+ *= require bootstrap_and_overrides
+ *= require flat-ui
  *= require_self
  *= require_tree .
 */


### PR DESCRIPTION
Per your request, adds Flat-UI from Darthdeus' gem, [flat-ui-rails](https://github.com/darthdeus/flat-ui-rails/blob/master/README.md).

It seems to look basically good; some newly green shows, etc. However, the top of the words, "Your Community" are cut off. Plus, the settings icon is too low. I speculate these will take some styling work; what, I don't know.  Here's how it looks:
![shot](https://f.cloud.github.com/assets/692702/317717/44e415f8-987e-11e2-922e-a61d964e8e3e.png)
Flat-UI is loaded after Twitter Bootstrap per this [answer](https://github.com/darthdeus/flat-ui-rails/issues/6#issuecomment-15594209) to your question at the gem. Of course Twitter Bootstrap must be first to avoid clobbering the others with the style normalization.
