### PR TITLE
generate high chart on entry model for landing page

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -15,4 +15,29 @@ class Entry
   validates :content, presence: true
   validates :category, presence: true
 
+  def self.mood_chart
+    LazyHighCharts::HighChart.new('pie') do |chart|
+      chart.options[:chart][:defaultSeriesType] = "pie"
+      chart.options[:chart][:height] = 210
+      chart.options[:title][:text] = 'Stuff affecting you the most'
+      chart.series({
+                     name: 'Total',
+                     data: fetch_categories
+                   })
+    end
+  end
+
+  def self.fetch_categories
+    categories = all.map do |entry|
+      entry.category
+    end
+
+    {}.tap do |h|
+      categories.each do |category|
+        h[category] ||= 0
+        h[category] += 1
+      end
+    end.to_a
+  end
+
 end

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -1,5 +1,12 @@
 <h3>Your Community</h3>
 <p>Connect with others dealing with similar issues</p>
+
+<div class="row">
+  <div class="span5 offset3">
+    <%= high_chart("chart_id", @users.mood_chart) %>
+  </div>
+</div>
+
 <div class="row">
   <div class="span12">
     <!-- Entry -->

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -3,7 +3,7 @@
 
 <div class="row">
   <div class="span5 offset3">
-    <%= high_chart("chart_id", @users.mood_chart) %>
+    <%= high_chart("chart_id", @entries.mood_chart) %>
   </div>
 </div>
 


### PR DESCRIPTION
This commit copies the chart generation method on the Entry model and fetches categories over all entries. You should change the chart title to reflect the change.
To remove duplication you could remove the mood_chart method from the user model and just use @user.entries.mood_chart instead, it should work.
