### PR TITLE
Improve UX of /entries and /users/:id

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -19,7 +19,7 @@ class Entry
     LazyHighCharts::HighChart.new('pie') do |chart|
       chart.options[:chart][:defaultSeriesType] = "pie"
       chart.options[:chart][:height] = 210
-      chart.options[:title][:text] = "A breakdown of things on everybody's mind"
+      chart.options[:title][:text] = "Issues on everybody's mind"
       chart.series({
                      name: 'Total',
                      data: fetch_categories

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User
     LazyHighCharts::HighChart.new('pie') do |chart|
       chart.options[:chart][:defaultSeriesType] = "pie"
       chart.options[:chart][:height] = 210
-      chart.options[:title][:text] = 'A breakdown of things on your mind'
+      chart.options[:title][:text] = 'Issues on your mind'
       chart.series({
                      name: 'Total',
                      data: fetch_categories

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -1,5 +1,13 @@
 <div class="row">
-  <div class="span5 offset3">
+  <div class="span6">
+    <br />
+    <br />
+    <br />
+    <p class="lead">
+      Journal your life issues and your therapist will read them before your next session
+    </p>
+  </div>
+  <div class="span6">
     <%= high_chart("chart_id", @entries.mood_chart) do |c|%>
        <%= "options.colors = #{chart_colors}".html_safe %>
     <% end %>

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -11,62 +11,53 @@
     <h2 class="text-info">
       Shared entries
     </h2>
+    <ul class="nav nav-list">
+      <li class="divider"></li>
+    </ul>
   </div>
 </div>
 
 <!-- Entry -->
 <% @entries.reverse.each do |entry| %>
 <div class="row">
-  <div class="span12">
-    <ul class="nav nav-list">
-      <li class="divider"></li>
-    </ul>
+  <div class="span7">
     <h4>
       <%= entry.title %>
     </h4>
   </div>
-  <div class="span9">
+</div>
+
+<div class="row">
+  <div class="span6">
     <p>
       <%= simple_format(entry.content) %>
     </p>
-  </div>
-  <div class="span3">
-    <span class="badge badge-info pull-right">14</span><br />
-    <span class="text-info pull-right"> know the feeling</span><br /><br />
-    <button class="btn btn-mini pull-right"
-            type="button"><i class="icon-heart"></i> been there</button>
-  </div>
-</div>
-<br />
-<div class="row">
-  <div class="span9">
     <span class="muted" data-toggle="tooltip" data-placement="right" title="Shared with community">
       <i class="icon-unlock"></i><small> by </small><i class="icon-user"> </i><small> anonymous on </small><i class="icon-calendar"> </i><small> <%= entry.created_at.to_date.strftime('%a %b %d, %Y') %> under</small>
       <span class="label label-info"><%= entry.category %></span>
     </span>
   </div>
-</div>
-<br />
-<div class="row">
-  <div class="span4">
+  <div class="span4 offset2">
+    <span class="badge badge-info pull-right">14</span><br />
+    <span class="text-info pull-right"> know the feeling</span><br /><br />
+    <button class="btn btn-mini pull-right"
+            type="button"><i class="icon-heart"></i> been there</button>
     <% if entry.happiness_level %>
-    <p class="muted"><small>happiness</small></p>
+    <p class="text-info">happiness</p>
     <div class="progress">
       <div class="bar bar-success" style="width: <%= width_for(entry.happiness_level) %>%;"></div>
     </div>
     <% end %>
-  </div>
-  <div class="span4">
+
     <% if entry.happiness_level %>
-    <p class="muted"><small>anxiety</small></p>
+    <p class="text-info">anxiety</p>
     <div class="progress">
       <div class="bar bar-warning" style="width: <%= width_for(entry.anxiety_level) %>%;"></div>
     </div>
     <% end %>
-  </div>
-  <div class="span4">
+
     <% if entry.irritation_level %>
-    <p class="muted"><small>irritation</small></p>
+    <p class="text-info">irritation</p>
     <div class="progress">
       <div class="bar bar-danger" style="width: <%= width_for(entry.irritation_level) %>%;"></div>
     </div>
@@ -74,4 +65,12 @@
   </div>
 </div>
 <br />
+<br />
+<div class="row">
+  <div class="span12">
+    <ul class="nav nav-list">
+      <li class="divider"></li>
+    </ul>
+  </div>
+</div>
 <% end %><!-- end of Entry -->

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -7,7 +7,7 @@
       Journal your life issues and your therapist will read them before your next session
     </p>
   </div>
-  <div class="span6">
+  <div class="span4">
     <%= high_chart("chart_id", @entries.mood_chart) do |c|%>
        <%= "options.colors = #{chart_colors}".html_safe %>
     <% end %>
@@ -36,7 +36,7 @@
 </div>
 
 <div class="row">
-  <div class="span6">
+  <div class="span8">
     <p>
       <%= simple_format(entry.content) %>
     </p>
@@ -45,7 +45,7 @@
       <span class="label label-info"><%= entry.category %></span>
     </span>
   </div>
-  <div class="span4 offset2">
+  <div class="span4">
     <span class="badge badge-info pull-right">14</span><br />
     <span class="text-info pull-right"> know the feeling</span><br /><br />
     <button class="btn btn-mini pull-right"

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,33 +11,27 @@
     <h2 class="text-info">
       Your entries
     </h2>
+    <ul class="nav nav-list">
+      <li class="divider"></li>
+    </ul>
   </div>
 </div>
 
 <!-- Entry -->
 <% @entries.reverse.each do |entry| %>
 <div class="row">
-  <div class="span12">
-    <ul class="nav nav-list">
-      <li class="divider"></li>
-    </ul>
+  <div class="span7">
     <h4>
       <%= entry.title %>
     </h4>
   </div>
-  <div class="span9">
+</div>
+
+<div class="row">
+  <div class="span6">
     <p>
       <%= simple_format(entry.content) %>
     </p>
-  </div>
-  <div class="span3">
-    <span class="badge badge-info pull-right">14</span><br />
-    <span class="text-info pull-right"> know the feeling</span>
-  </div>
-</div>
-<br />
-<div class="row">
-  <div class="span9">
     <% if entry.published? %>
     <span class="muted" data-toggle="tooltip" data-placement="right" title="Shared with community">
       <i class="icon-unlock"></i><small> on </small><i class="icon-calendar"> </i><small> <%= entry.created_at.to_date.strftime('%a %b %d, %Y') %> under</small>
@@ -50,7 +44,10 @@
     </span>
     <% end %>
   </div>
-  <div class="span3">
+  <div class="span4 offset2">
+    <span class="badge badge-info pull-right">14</span><br />
+    <span class="text-info pull-right"> know the feeling</span><br />
+
     <div class="btn-toolbar pull-right">
       <div class="btn-group">
         <%= link_to raw('<i class="icon-edit"></i>'),
@@ -61,28 +58,23 @@
         class: "btn" %>
       </div>
     </div>
-  </div>
-</div>
-<div class="row">
-  <div class="span4">
+    <br />
     <% if entry.happiness_level %>
-    <p class="muted"><small>happiness</small></p>
+    <p class="text-info">happiness</p>
     <div class="progress">
       <div class="bar bar-success" style="width: <%= width_for(entry.happiness_level) %>%;"></div>
     </div>
     <% end %>
-  </div>
-  <div class="span4">
-    <% if entry.anxiety_level %>
-    <p class="muted"><small>anxiety</small></p>
+
+    <% if entry.happiness_level %>
+    <p class="text-info">anxiety</p>
     <div class="progress">
       <div class="bar bar-warning" style="width: <%= width_for(entry.anxiety_level) %>%;"></div>
     </div>
     <% end %>
-  </div>
-  <div class="span4">
+
     <% if entry.irritation_level %>
-    <p class="muted"><small>irritation</small></p>
+    <p class="text-info">irritation</p>
     <div class="progress">
       <div class="bar bar-danger" style="width: <%= width_for(entry.irritation_level) %>%;"></div>
     </div>
@@ -90,4 +82,12 @@
   </div>
 </div>
 <br />
+<br />
+<div class="row">
+  <div class="span12">
+    <ul class="nav nav-list">
+      <li class="divider"></li>
+    </ul>
+  </div>
+</div>
 <% end %><!-- end of Entry -->

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <div class="row">
-  <div class="span6">
+  <div class="span8">
     <p>
       <%= simple_format(entry.content) %>
     </p>
@@ -44,7 +44,7 @@
     </span>
     <% end %>
   </div>
-  <div class="span4 offset2">
+  <div class="span4">
     <span class="badge badge-info pull-right">14</span><br />
     <span class="text-info pull-right"> know the feeling</span><br />
 


### PR DESCRIPTION
@billiedemott Here are screenshots of the new UI for /entries and /users/:id. Please review the design and the code and comment that everything looks good. You can see the changes live on the production site.
### /entries

![screen shot 2013-08-02 at 7 16 03 pm](https://f.cloud.github.com/assets/331004/904544/a4cb174c-fbc9-11e2-8474-9ea8b555760e.png)
### /users/:id

![screen shot 2013-08-02 at 7 16 31 pm](https://f.cloud.github.com/assets/331004/904545/ae04603e-fbc9-11e2-9d44-a0640de7a612.png)

PS. We're following this process according to our application management policy https://github.com/akshatpradhan/information-security-policy#application-management-policy
