### PR TITLE
fix: pie chart on landing page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def index
-    @entries = Entry.where(published: true).desc(:created_at).limit(3)
+    @entries = Entry.where(published: true)
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -15,6 +15,12 @@ class Entry
   validates :content, presence: true
   validates :category, presence: true
 
+  # Syntactic sugar for class method
+  # def self.recent(3)
+  #   desc(:created_at).limit(3)
+  # end
+  scope :latest, desc(:created_at).limit(3)
+
   def self.mood_chart
     LazyHighCharts::HighChart.new('pie') do |chart|
       chart.options[:chart][:defaultSeriesType] = "pie"

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -105,7 +105,7 @@
 </div>
 
 <!-- Entry -->
-<% @entries.each do |entry| %>
+<% @entries.latest.each do |entry| %>
 <div class="row">
   <div class="span7">
     <h4>

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -18,4 +18,15 @@ describe Entry do
     end
   end
 
+  describe ".latest" do
+    before do
+      FactoryGirl.create(:user_with_entries, entries_count: 5)
+    end
+    it "should return 3 latest entries" do
+      #  MongoDB count method ignores limit in queries. So use .entries.
+      # .entries method returns the query result as an array, similar to the
+      # .to_a method which works as well.
+      Entry.latest.entries.count.should == 3
+    end
+  end
 end


### PR DESCRIPTION
- create latest scope to show only 3 entries on landing page
- pie chart now calculates all categories

Pie chart on landing page now shows more then 3 categories but only 3 entries show up on landing page.
![screen shot 2013-09-18 at 10 45 04 am](https://f.cloud.github.com/assets/331004/1166009/9cdf4d34-2075-11e3-8274-b0ac39f362aa.png)
