### PR TITLE
fix: empty emotional state bars from being shown

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @entries = @user.entries.all
+    @entries = @user.entries
   end
 
 end

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -45,21 +45,21 @@
       <i class="icon-heart"></i> been there
     </button>
     <br /><br /><br />
-    <% if entry.happiness_level %>
+    <% if entry.happiness_level && entry.happiness_level > 0 %>
     <p class="text-success">happiness</p>
     <div class="progress">
       <div class="bar bar-success" style="width: <%= width_for(entry.happiness_level) %>%;"></div>
     </div>
     <% end %>
 
-    <% if entry.anxiety_level %>
+    <% if entry.anxiety_level && entry.anxiety_level > 0 %>
     <p class="text-warning">anxiety</p>
     <div class="progress">
       <div class="bar bar-warning" style="width: <%= width_for(entry.anxiety_level) %>%;"></div>
     </div>
     <% end %>
 
-    <% if entry.irritation_level %>
+    <% if entry.irritation_level && entry.irritation_level > 0 %>
     <p class="text-danger">irritation</p>
     <div class="progress">
       <div class="bar bar-danger" style="width: <%= width_for(entry.irritation_level) %>%;"></div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -133,21 +133,21 @@
       <i class="icon-heart"></i> been there
     </button>
     <br /><br /><br />
-    <% if entry.happiness_level %>
+    <% if entry.happiness_level && entry.happiness_level > 0 %>
     <p class="text-success">happiness</p>
     <div class="progress">
       <div class="bar bar-success" style="width: <%= width_for(entry.happiness_level) %>%;"></div>
     </div>
     <% end %>
 
-    <% if entry.anxiety_level %>
+    <% if entry.anxiety_level && entry.anxiety_level > 0 %>
     <p class="text-warning">anxiety</p>
     <div class="progress">
       <div class="bar bar-warning" style="width: <%= width_for(entry.anxiety_level) %>%;"></div>
     </div>
     <% end %>
 
-    <% if entry.irritation_level %>
+    <% if entry.irritation_level && entry.irritation_level > 0 %>
     <p class="text-danger">irritation</p>
     <div class="progress">
       <div class="bar bar-danger" style="width: <%= width_for(entry.irritation_level) %>%;"></div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -62,21 +62,21 @@
       </div>
     </div>
     <br /><br /><br />
-    <% if entry.happiness_level %>
+    <% if entry.happiness_level && entry.happiness_level > 0 %>
     <p class="text-success">happiness</p>
     <div class="progress">
       <div class="bar bar-success" style="width: <%= width_for(entry.happiness_level) %>%;"></div>
     </div>
     <% end %>
 
-    <% if entry.anxiety_level %>
+    <% if entry.anxiety_level && entry.anxiety_level > 0 %>
     <p class="text-warning">anxiety</p>
     <div class="progress">
       <div class="bar bar-warning" style="width: <%= width_for(entry.anxiety_level) %>%;"></div>
     </div>
     <% end %>
 
-    <% if entry.irritation_level %>
+    <% if entry.irritation_level && entry.irritation_level > 0 %>
     <p class="text-danger">irritation</p>
     <div class="progress">
       <div class="bar bar-danger" style="width: <%= width_for(entry.irritation_level) %>%;"></div>

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -5,6 +5,14 @@ FactoryGirl.define do
     content "i'm sick & its annoying bc i need to work but I'm tired as hell."
     category "just feeling off"
     published "true"
+    happiness_level "1"
     anxiety_level "5"
+    irritation_level "3"
+    user # add an associated user to the entry factory
+    factory :entry_without_emotional_state do
+      happiness_level "0"
+      anxiety_level "0"
+      irritation_level "0"
+    end
   end
 end

--- a/spec/features/user_journal_spec.rb
+++ b/spec/features/user_journal_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+feature "User wanting to view entries" do
+
+  let(:user) {FactoryGirl.create(:user)}
+
+  background do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:facebook] = {
+      'uid'  => '100004721472441',
+      'provider' => 'facebook',
+      'info' => {
+        'name' => 'Bob Raymond',
+      }
+    }
+    visit signin_path
+  end
+  %w(happiness anxiety irritation).each do |emotional_state|
+    scenario "#{emotional_state} bar should be visible when value is > 0" do
+      FactoryGirl.create(:entry, user: user)
+      visit entries_path
+      page.should have_content(emotional_state)
+      visit home_path
+      page.should have_content(emotional_state)
+      visit user_path(user)
+      page.should have_content(emotional_state)
+    end
+
+    scenario "anxiety bar should not be visible when value is 0" do
+      entry = FactoryGirl.create(:entry_without_emotional_state, user: user)
+      visit entries_path
+      page.should_not have_content(emotional_state)
+      visit home_path
+      page.should_not have_content(emotional_state)
+      visit user_path(user)
+      page.should_not have_content(emotional_state)
+    end
+  end
+end


### PR DESCRIPTION
- fix views for emotional state bars so that they are visible only when
  > 0
- add entry_without_emotional_state factory
- add tests for emotional state bars
- remove .all from users_controller since its redundant

Basically stop this from happening (see empty anxiety bar)
![screen shot 2013-09-18 at 1 25 48 pm](https://f.cloud.github.com/assets/331004/1167054/68202fd4-2087-11e3-8d2e-c41286f502ca.png)
