### PR TITLE
Bug fixes, views and helper refactorings, better specs and more test cases

### DIFF
--- a/app/helpers/entries_helper.rb
+++ b/app/helpers/entries_helper.rb
@@ -5,16 +5,24 @@ module EntriesHelper
   end
 
   def like_status_for(entry, user)
-    return "Nobody knows the feeling." if entry.likes == 0
+    return "No one else knows the feeling." if entry.likes == 0
     out = []
-    if entry.liked? user
-      out << "You"
-      out << "and" if entry.likes > 1
-      out << "<b>#{entry.likes - 1}</b> others" if entry.likes > 1
-    else
-      out << "<b>#{entry.likes}</b> others" if entry.likes > 1
+    if entry.likes == 1
+      if user == entry.user
+        out << "Another person knows"
+      else
+        out << "You know"
+      end
+    else#likes > 1
+      if user == entry.user
+        likes = entry.likes
+      else
+        likes = entry.likes - 1
+        out << "You and"
+      end
+      out << "<b>#{likes}</b> others know"
     end
-    out << "know the feeling."
+    out << "the feeling."
     out.join(" ").html_safe
   end
 

--- a/app/helpers/entries_helper.rb
+++ b/app/helpers/entries_helper.rb
@@ -8,17 +8,17 @@ module EntriesHelper
     return "No one else knows the feeling." if entry.likes == 0
     out = []
     if entry.likes == 1
-      if user == entry.user
-        out << "Another person knows"
-      else
+      if entry.liked?(user)
         out << "You know"
+      else
+        out << "Another person knows"
       end
     else#likes > 1
-      if user == entry.user
-        likes = entry.likes
-      else
+      if entry.liked?(user)
         likes = entry.likes - 1
         out << "You and"
+      else
+        likes = entry.likes
       end
       out << "<b>#{likes}</b> others know"
     end
@@ -27,15 +27,17 @@ module EntriesHelper
   end
 
   def like_button_for(entry, user)
-    if entry.liked?(user)
-      like_or_unlike_action = unlike_entry_path(entry)
-      css_class = "active"
-      title = " un-been there"
-    else
-      like_or_unlike_action = like_entry_path(entry)
-      css_class = ""
-      title = " been there"
+    unless user == entry.user
+      if entry.liked?(user)
+        like_or_unlike_action = unlike_entry_path(entry)
+        css_class = "active"
+        title = " un-been there"
+      else
+        like_or_unlike_action = like_entry_path(entry)
+        css_class = ""
+        title = " been there"
+      end
+      return link_to(content_tag(:i, nil, class: "icon-heart") + title, like_or_unlike_action, method: :put, remote: true, class: "btn btn-mini btn-inverse pull-right #{css_class}")
     end
-    return link_to(content_tag(:i, nil, class: "icon-heart") + title, like_or_unlike_action, method: :put, remote: true, class: "btn btn-mini btn-inverse pull-right #{css_class}")
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -46,7 +46,9 @@
   </div>
   <div class="span3 offset1">
     <span class="pull-right">
-      You and <b><%= rand(10) %></b> others know the feeling
+      <div class="like_status" id="entry_status_<%= entry.id %>">
+        <%= like_status_for(entry, current_user) %>
+      </div>
     </span>
     <br /><br />
     <div class="btn-toolbar pull-right">

--- a/spec/features/been_there_spec.rb
+++ b/spec/features/been_there_spec.rb
@@ -28,11 +28,11 @@ feature "Users can like shared entries" do
     let!(:entry) { FactoryGirl.create(:entry, user: FactoryGirl.create(:user)) }
     scenario "page should return 'you know the feeling'", js: true do
       visit entries_path
-      page.should have_content "Nobody knows the feeling."
+      page.should have_content "No one else knows the feeling."
       click_link "been there"
       page.should have_content "You know the feeling."
       click_link "un-been there"
-      page.should have_content "Nobody knows the feeling."
+      page.should have_content "No one else knows the feeling."
     end
     scenario "been there button should become un-been there", js: true do
       visit entries_path

--- a/spec/features/been_there_spec.rb
+++ b/spec/features/been_there_spec.rb
@@ -16,31 +16,21 @@ feature "Users can like shared entries" do
   end
 
   context "with no user logged in" do
-    let!(:entry) { FactoryGirl.create(:entry, user: FactoryGirl.create(:user)) }
-    scenario "been there button should redirect to sign in page", js: true do
+    scenario "been there button should invite user to sign in", js: true do
+      FactoryGirl.create(:entry, user: FactoryGirl.create(:user))
       visit signout_path
       click_link "been there"
       page.should have_content "You need to sign in to like an entry."
     end
   end
 
-  context "entry with no likes" do
-    let!(:entry) { FactoryGirl.create(:entry, user: FactoryGirl.create(:user)) }
-    scenario "page should return 'you know the feeling'", js: true do
-      visit entries_path
-      page.should have_content "No one else knows the feeling."
-      click_link "been there"
-      page.should have_content "You know the feeling."
-      click_link "un-been there"
-      page.should have_content "No one else knows the feeling."
-    end
-    scenario "been there button should become un-been there", js: true do
-      visit entries_path
-      click_link "been there"
-      page.should have_link "un-been there"
-      click_link "un-been there"
-      page.should have_link "been there"
-    end
+  scenario "been there button should become un-been there", js: true do
+    FactoryGirl.create(:entry, user: FactoryGirl.create(:user))
+    visit entries_path
+    click_link "been there"
+    page.should have_link "un-been there"
+    click_link "un-been there"
+    page.should have_link "been there"
   end
 
   context "multiple entries" do

--- a/spec/helpers/entries_helper_spec.rb
+++ b/spec/helpers/entries_helper_spec.rb
@@ -39,13 +39,18 @@ describe EntriesHelper do
             .should == "Another person knows the feeling."
         end
       end
-      context "when the viewing user is not the entry creator" do
+      context "when the viewing user is a liker" do
         it "shows 'You know the feeling'" do
           helper.like_status_for(entry, user)
             .should == "You know the feeling."
         end
       end
-
+      context "when the viewing user is not a liker" do
+        it "shows 'Another person knows the feeling'" do
+          helper.like_status_for(entry, FactoryGirl.create(:user))
+            .should == "Another person knows the feeling."
+        end
+      end
     end
     context "an entry with N likes" do
       let!(:entry) {FactoryGirl.create(:entry, user: FactoryGirl.create(:user), likes: 5)}
@@ -61,6 +66,30 @@ describe EntriesHelper do
           entry.like(user)
           helper.like_status_for(entry, user)
             .should == "You and <b>5</b> others know the feeling."
+        end
+      end
+    end
+  end
+
+  describe "#like_button_for" do
+    let!(:entry) {FactoryGirl.create(:entry, user: FactoryGirl.create(:user), likes: 5)}
+    context "when the viewing user is the entry creator" do
+      it "should not render a button" do
+        helper.like_button_for(entry, entry.user).should be_nil
+      end
+    end
+    context "when the viewing user is the not the entry creator" do
+      context "if he's not a liker of the entry" do
+        it "should render a 'been there' button" do
+          user = FactoryGirl.create(:user)
+          helper.like_button_for(entry, user).should match(/been there/)
+        end
+      end
+      context "if he's a liker of the entry" do
+        it "should render an 'un-been there' button" do
+          user = FactoryGirl.create(:user)
+          entry.like(user)
+          helper.like_button_for(entry, user).should match(/un-been there/)
         end
       end
     end

--- a/spec/helpers/entries_helper_spec.rb
+++ b/spec/helpers/entries_helper_spec.rb
@@ -11,4 +11,58 @@ describe EntriesHelper do
 
   end
 
+  describe "#like_status_for" do
+    context "an entry with 0 likes" do
+      let!(:entry) {FactoryGirl.create(:entry, user: FactoryGirl.create(:user), likes: 0)}
+      context "when the viewing user is the entry creator" do
+        it "shows 'No one else knows the feeling'" do
+          helper.like_status_for(entry, entry.user)
+            .should == "No one else knows the feeling."
+        end
+      end
+      context "when the viewing user is not the entry creator" do
+        it "shows 'No one else knows the feeling'" do
+          helper.like_status_for(entry, FactoryGirl.create(:user))
+            .should == "No one else knows the feeling."
+        end
+      end
+    end
+    context "an entry with 1 like" do
+      let!(:entry) {FactoryGirl.create(:entry, user: FactoryGirl.create(:user))}
+      let!(:user) {FactoryGirl.create(:user)}
+      before(:each) do
+        entry.like(user)
+      end
+      context "when the viewing user is the entry creator" do
+        it "shows 'Another person knows the feeling'" do
+          helper.like_status_for(entry, entry.user)
+            .should == "Another person knows the feeling."
+        end
+      end
+      context "when the viewing user is not the entry creator" do
+        it "shows 'You know the feeling'" do
+          helper.like_status_for(entry, user)
+            .should == "You know the feeling."
+        end
+      end
+
+    end
+    context "an entry with N likes" do
+      let!(:entry) {FactoryGirl.create(:entry, user: FactoryGirl.create(:user), likes: 5)}
+      context "when the viewing user is the entry creator" do
+        it "shows 'N others know the feeling'" do
+          helper.like_status_for(entry, entry.user)
+            .should == "<b>5</b> others know the feeling."
+        end
+      end
+      context "when the viewing user is not the entry creator" do
+        it "shows 'You and N others know the feeling'" do
+          user = FactoryGirl.create(:user)
+          entry.like(user)
+          helper.like_status_for(entry, user)
+            .should == "You and <b>5</b> others know the feeling."
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I should have done more granular commits... I'll do that for the next pull requests :)

So to sum up the changes : 
1.  Included some conditions for when the entry creator visits entries. I added different logic conditions in the `like_status_for` helper to render a better phrase (tell me if you think it needs a different logic and feel free to change the phrases).
2.  Added the `like_status_for` helper to `users/show` view.
3.  Rephrased and moved specs from `spec/features` to `spec/helpers`. This fixes some horrible bugs in the specs which started giving me a bad headache...
4.  I modified the `like_button_for` helper to check whether the current_user is the entry creator. In this case the button isn't rendered. I can leverage on this modification for the future views refactoring (home/index, entries/index, users/show).
5.  I added specs for the `like_button_for` helper.
