### PR TITLE
fix: links in email for correct path containing www subdomain

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Spoutlets::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  config.action_mailer.default_url_options = { host: 'spoutlets.com' }
+  config.action_mailer.default_url_options = { host: 'www.spoutlets.com' }
   # ActionMailer Config
   # Setup for production - deliveries, no errors raised
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
Change my password goes to the appropriate link
![screen shot 2013-10-04 at 1 10 10 pm](https://f.cloud.github.com/assets/331004/1271228/e203d6b0-2d17-11e3-9c10-96487900c4ac.png)
