### PR TITLE
fixing signup/signin views

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,9 @@
 class UsersController < ApplicationController
   before_filter :authenticate_user!, except: [:new, :create]
   load_and_authorize_resource
+
+  helper_method :devise_mapping, :resource_name, :resource_class
+
   def index
     @users = User.all
   end
@@ -40,4 +43,17 @@ class UsersController < ApplicationController
     @entries = @user.entries
   end
 
+  private
+
+  def devise_mapping
+    Devise.mappings[:user]
+  end
+
+  def resource_name
+    devise_mapping.name
+  end
+
+  def resource_class
+    devise_mapping.to
+  end
 end

--- a/app/views/users/shared/_links.erb
+++ b/app/views/users/shared/_links.erb
@@ -3,21 +3,16 @@
     Already have an account?
   </h6>
   <%= link_to "Sign in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if controller_name != 'users' %>
   <h6>
     Don't have an account?
   </h6>
   <%= link_to "Sign up", signup_path %><br />
-<% end -%>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
-  <h6>
-    Don't have an account?
-  </h6>
-  <%= link_to "Sign up", signup_path %><br />
   <h6>
     Forgot password?
   </h6>

--- a/spec/features/user_journal_spec.rb
+++ b/spec/features/user_journal_spec.rb
@@ -9,10 +9,10 @@ feature "User wanting to view entries" do
     #NOTE: since a user has already signed in in the background section, I need to sign him out
     visit signout_path
     visit signup_path
-    click_button "Register"
+    click_button "Create your account"
     page.should have_content "You must provide a valid email address to register!"
     fill_in "user_email", with: "test@test.com"
-    click_button "Register"
+    click_button "Create your account"
     page.should have_content "Welcome! You have signed up successfully."
     page.should have_content 'Shared entries'
     current_path.should == entries_path
@@ -24,6 +24,20 @@ feature "User wanting to view entries" do
     page.should have_content "Signed in successfully."
     visit signout_path
     page.should have_content "Signed out successfully."
+  end
+
+  scenario "is offered to signup from the signin page" do
+    visit signout_path
+    visit signin_path
+    page.should have_content "Don't have an account?"
+    page.should have_link("Sign up")
+  end
+
+  scenario "is offered to signin from the signup page" do
+    visit signout_path
+    visit signup_path
+    page.should have_content "Already have an account?"
+    page.should have_link("Sign in")
   end
 
   %w(happiness anxiety irritation).each do |emotional_state|

--- a/spec/support/auth_macros.rb
+++ b/spec/support/auth_macros.rb
@@ -4,6 +4,6 @@ module AuthMacros
     visit signin_path
     fill_in "user_email", with: user.email
     fill_in "user_password", with: user.password
-    click_on "Sign in"
+    click_on "Login"
   end
 end


### PR DESCRIPTION
The user registration page is not directly managed by devise (note the :registerable module is not included in the user model devise call) since we are making the registration process easier by not requiring a password (this is randomly generated and mailed to the user, if you remember).

That's the reason why the _links partial explodes with those errors. To fix this I added 3 helpers methods in the users_controller to define the devise variables `devise_mapping`, `resource_name` and `resource_class`.

Another problem was the link to signup not being displayed in the signin view. To fix this I changed the logic by checking if the current controller is not "users_controller" (which is used for register a new user) in which case I want to render the signup link.

I added 2 specs to check the rendering of the signup/signin links in the signin/signup views and made some changes to the existing specs to reflect the changes in the UI.
