### PR TITLE
make layouts consistent

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,13 +11,15 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 //= require jquery
+//= require jquery.ui.button
 //= require jquery.ui.datepicker
 //= require jquery.ui.slider
 //= require jquery.ui.spinner
 //= require jquery.ui.tooltip
 //= require jquery.ui.effect
 //= require jquery_ujs
-//= require bootstrap-slider
 //= require twitter/bootstrap
+//= require flatuipro
 //= require highcharts/highcharts
+//= require bootstrap-slider
 //= require_tree .

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -7,7 +7,7 @@
       <%= f.input_field :title, class: "span6" %>
     <% end %>
   </div>
-  <div class="span4 offset1">
+  <div class="span4">
     <%= f.input :published,
         as: :boolean,
         label: "Share with community",
@@ -66,9 +66,10 @@
     </div>
   </div>
 </div>
-<div class="form-actions">
-  <%= f.button :submit, "Log it!",
-      class: "btn-large btn-block btn-primary" %>
+<div class="row">
+  <div class="span12">
+    <%= f.button :submit, "Log it!",
+        class: "btn-large btn-block btn-primary" %>
+  </div>
 </div>
-
 <% end %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -39,7 +39,7 @@
         <a href="#" class="dropdown-toggle"
         data-toggle="dropdown">register or login<b class="caret"></b></a>
         <ul class="dropdown-menu">
-          <li><%= link_to "for patients", signin_path %></li>
+          <li><%= link_to "for people", signin_path %></li>
           <li class="divider"></li>
           <li><%= link_to "for therapists",  therapist_omniauth_authorize_path(:linkedin)%></li>
         </ul>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,10 +7,10 @@
   <div class="span3 offset2">
   <%= simple_form_for @user do |f| %>
     <%= f.error_notification %>
-
-    <div class="form-inputs">
-      <%= f.input :email, required: true, autofocus: true %>
-    </div>
+    <%= f.input :email,
+        required: true,
+        autofocus: true,
+        input_html: { class: 'input-xlarge' } %>
     <%= f.button :submit, "Create your account",
         class: "btn-primary btn-large pull-right" %>
   <% end %>
@@ -19,7 +19,7 @@
   <br /><br /><br />
   <h4 class="text-center">or</h4>
   </div>
-  <div class="span5">
+  <div class="span4">
     <div class="well">
       <%= render "users/shared/links" %>
     </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -5,24 +5,21 @@
 </div>
 <div class="row">
   <div class="span3 offset2">
-  <%= simple_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f| %>
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= f.error_notification %>
-
-    <div class="form-inputs">
-      <%= f.input :email, :required => true, :autofocus => true %>
-    </div>
-
-
+    <%= f.input :email,
+        required: true,
+        autofocus: true,
+        input_html: { class: 'input-xlarge' } %>
     <%= f.button :submit, "Reset password",
         class: "btn-primary btn-large pull-right" %>
-
   <% end %>
   </div>
   <div class="span2">
   <br /><br /><br />
   <h4 class="text-center">or</h4>
   </div>
-  <div class="span5">
+  <div class="span4">
     <div class="well">
       <%= render "users/shared/links" %>
     </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -5,11 +5,16 @@
 </div>
 <div class="row">
   <div class="span3 offset2">
-    <%= simple_form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f| %>
-      <%= f.input :email, :required => false, :autofocus => true %>
-      <%= f.input :password, :required => false %>
+    <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= f.input :email,
+          required: false,
+          autofocus: true,
+          input_html: { class: 'input-xlarge' } %>
+      <%= f.input :password,
+          required: false,
+          input_html: { class: 'input-xlarge' } %>
       <%= f.input :remember_me,
-          input_html: { data: {toggle: :checkbox} },
+          input_html: { data: { toggle: :checkbox } },
           as: :boolean if devise_mapping.rememberable? %>
       <%= f.button :submit, "Login",
           class: "btn-primary btn-large pull-right" %>
@@ -25,4 +30,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This PR makes the layout of register/login/forgot password consistent. It also changes some copy and removes a well, and corrects the loading order of the sliders so that it displays first.

Remove well from Log It
![screen shot 2013-10-10 at 9 04 09 pm](https://f.cloud.github.com/assets/331004/1314208/d465945c-326d-11e3-93ad-6b8a3e134274.png)

Login
![screen shot 2013-10-11 at 8 04 36 am](https://f.cloud.github.com/assets/331004/1314209/e3582f60-326d-11e3-8f40-2879fceb6a8f.png)

Register
![screen shot 2013-10-11 at 8 04 51 am](https://f.cloud.github.com/assets/331004/1314211/ea8201f8-326d-11e3-8c6d-c3850d13f4f6.png)

Forgot password
![screen shot 2013-10-11 at 4 25 49 pm](https://f.cloud.github.com/assets/331004/1318011/5e601728-32b3-11e3-8e41-7519454b4b4d.png)

For people instead of for patients
![screen shot 2013-10-11 at 8 04 21 am](https://f.cloud.github.com/assets/331004/1314218/26bd445c-326e-11e3-9a8b-f5a482f0334e.png)
